### PR TITLE
Update .gitignore to match create-redwood-app template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .env
 .netlify
@@ -7,8 +8,13 @@ dist
 dist-babel
 node_modules
 yarn-error.log
-redwood/*
 web/public/mockServiceWorker.js
 web/types/graphql.d.ts
 api/types/graphql.d.ts
-web/public/mockServiceWorker.js
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
I noticed that the package.json also diverged a bit from the `create-redwood-app` template, and maybe there's other files too that need to be updated, I could take care of that too.