### PR TITLE
BlogLayout "loggedIn" story doesn't render user

### DIFF
--- a/web/src/layouts/BlogLayout/BlogLayout.stories.js
+++ b/web/src/layouts/BlogLayout/BlogLayout.stories.js
@@ -1,7 +1,7 @@
 import BlogLayout from './BlogLayout'
 
 export const loggedIn = () => {
-  mockCurrentUser({ email: 'rob@redwoodjs.com' })
+  mockCurrentUser({ email: 'rob@redwoodjs.com', isAuthenticated: true })
 
   return <BlogLayout />
 }


### PR DESCRIPTION
Fixes #52

## 🪲 The Bug

The `loggedIn` story calls `mockCurrentUser` and passes in the email address but the Logout link and user email do not display. 

This would mean `isAuthenticated` is false, as that is the case where the navigation displays "Login".

As you will see in the screenshot below, there is no difference between the two stories. 

![image](https://user-images.githubusercontent.com/53096355/167272009-8e7965d7-3f96-4e6b-9603-66bfdeed678d.png)

## 🛠️ The Fix

By passing `isAuthenticated: true` to `mockCurrentUser`, the Logout button and user email load as expected. 

![image](https://user-images.githubusercontent.com/53096355/167272055-cf947fe5-af44-4063-abac-a325d015956d.png)

> Developed on GitPod 🚀