### PR TITLE
fix: Add id to mockCurrentUser

### DIFF
--- a/web/src/layouts/BlogLayout/BlogLayout.test.js
+++ b/web/src/layouts/BlogLayout/BlogLayout.test.js
@@ -4,7 +4,7 @@ import BlogLayout from './BlogLayout'
 
 const EMAIL = 'rob@redwoodjs.com'
 const loggedIn = () => {
-  mockCurrentUser({ email: EMAIL })
+  mockCurrentUser({ id: 1, email: EMAIL })
 }
 const loggedOut = () => {
   mockCurrentUser(null)


### PR DESCRIPTION
According to Typescript mockCurrentUser expects a required id.

In Javascript we don't notice this.

Come to think of it... Should this tutorial be in Typescript? Or maybe should we offer a Typescript version?